### PR TITLE
add, fix: 블로그 다크모드 적용(using tailwind config, next-themes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gray-matter": "^4.0.3",
     "next": "^13.4.4",
     "next-sitemap": "^4.1.3",
+    "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.9",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.dark .markdown-viewer h2 {
+  color: white;
+}
+
+.dark .markdown-viewer h3 {
+  color: white;
+}
+
+.dark .markdown-viewer blockquote {
+  color: white;
+}
+
+.dark .markdown-viewer a {
+  color: white;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Open_Sans } from 'next/font/google';
 import { Metadata } from 'next';
 import classNames from 'classnames';
 import { PageHeader, PageFooter } from '@components/layout';
+import Providers from '@components/Providers';
 import {
   GOOGLE_VERIFICATION_CODE,
   NAVER_VERIFICATION_CODE,
@@ -26,14 +27,6 @@ export const metadata: Metadata = {
       'naver-site-verification': NAVER_VERIFICATION_CODE,
     },
   },
-  openGraph: {
-    title: '도토리정의 DevLog',
-    description: '프론트엔드 개발자 도토리정의 블로그 입니다.',
-    url: 'https://dotorimook-log.vercel.app/',
-    siteName: "Dotori Jung's Blog Application",
-    locale: 'ko_KR',
-    type: 'website',
-  },
 };
 
 export default function RootLayout({
@@ -43,10 +36,12 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={classNames(sans.className, 'scroll-smooth')}>
-      <body className="flex min-h-screen flex-col bg-light selection:bg-purple-400 selection:text-white">
-        <PageHeader />
-        <main className="mx-auto w-full max-w-7xl grow p-8">{children}</main>
-        <PageFooter />
+      <body className="flex min-h-screen flex-col bg-light selection:bg-purple-400 selection:text-white dark:bg-stone-900">
+        <Providers>
+          <PageHeader />
+          <main className="mx-auto w-full max-w-7xl grow p-8">{children}</main>
+          <PageFooter />
+        </Providers>
       </body>
     </html>
   );

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import { ThemeProvider } from "next-themes"
+
+const Providers = ({ children }: { children: React.ReactNode }) => {
+	return (
+		<ThemeProvider enableSystem={true} attribute="class">
+			{children}
+		</ThemeProvider>
+	)
+}
+
+export default Providers

--- a/src/components/categories/Categories.tsx
+++ b/src/components/categories/Categories.tsx
@@ -17,7 +17,7 @@ export default function Categories({
 
   return (
     <div className="">
-      <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl">
+      <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl dark:text-white">
         Categories You&apos;ve Selected
       </h2>
       <CarouselCategories

--- a/src/components/layout/banner/index.tsx
+++ b/src/components/layout/banner/index.tsx
@@ -24,19 +24,18 @@ export default function PageBanner() {
   return (
     <div className="flex justify-center">
       <div className="flex w-full flex-col items-center justify-center md:w-3/5 md:items-start">
-        <h2 className="mb-4 select-none text-2xl font-extrabold text-slate-800 md:text-3xl lg:text-5xl">
+        <h2 className="mb-4 select-none text-2xl font-extrabold text-slate-800 md:text-3xl lg:text-5xl dark:text-white">
           Hello, I&apos;m{' '}
-          <span className="text-purple-500">
+          <span className="text-purple-500 dark:text-purple-600">
             <ReactRotatingText
               items={['Kwangmook', 'Creative Dev', 'Junior Dev']}
             />
           </span>
-          .
         </h2>
-        <h2 className="mb-8 select-none text-2xl font-extrabold text-slate-800 md:text-3xl lg:text-5xl">
+        <h2 className="mb-8 select-none text-2xl font-extrabold text-slate-800 md:text-3xl lg:text-5xl dark:text-white">
           Frontend Developer 🌞
         </h2>
-        <p className="mb-7 text-lg font-medium text-slate-500 md:text-xl lg:text-2xl">
+        <p className="mb-7 text-lg font-medium text-slate-500 md:text-xl lg:text-2xl dark:text-slate-300">
           안녕하세요! 2년차에 접어든 프론트엔드 개발자 정광묵 입니다. 꾸준함을
           유지하는 개발자를 지향합니다. 여행, 독서, 음식을 좋아합니다.✈️📚🍱
         </p>
@@ -55,7 +54,7 @@ export default function PageBanner() {
       </div>
       <div className="hidden grow justify-center md:flex">
         <Image
-          className="h-72 w-72 rounded-full object-cover p-4 shadow-2xl brightness-110 lg:h-96 lg:w-96"
+          className="h-72 w-72 rounded-full object-cover p-4 shadow-2xl brightness-110 lg:h-96 lg:w-96 dark:bg-slate-200 dark:shadow-slate-300"
           src={backgroundArr[randomImageIndex]}
           alt="Main Image"
           priority

--- a/src/components/layout/footer/index.tsx
+++ b/src/components/layout/footer/index.tsx
@@ -12,13 +12,13 @@ import {
 export default function PageFooter() {
   return (
     <footer className="sticky bottom-0 w-full text-center text-white">
-      <div className="flex justify-center space-x-5 bg-slate-100 py-3.5 text-2xl">
+      <div className="flex justify-center space-x-5 bg-slate-100 py-3.5 text-2xl dark:bg-stone-800">
         {SOCIAL_LOGOS.map(({ id, logo, link }) => (
           <Link href={link} legacyBehavior key={id}>
             <a
               target="_blank"
               rel="noopener noreferrer"
-              className="text-neutral-500 hover:text-neutral-800"
+              className="text-neutral-500 hover:text-neutral-800 dark:text-white"
             >
               {logo}
             </a>
@@ -26,7 +26,7 @@ export default function PageFooter() {
         ))}
       </div>
 
-      <div className="bg-neutral-800 p-2 text-center text-sm font-medium text-white">
+      <div className="bg-neutral-800 p-2 text-center text-sm font-medium text-white dark:bg-stone-900">
         © 2023 Copyright{' '}
         <Link className="" href="https://github.com/seolleung2" legacyBehavior>
           <a target="_blank" rel="noopener noreferrer">

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -12,11 +12,11 @@ export default function PageHeader() {
   const [isOpenDropdown, setIsOpenDropdown] = useState<boolean>(false);
 
   return (
-    <header className="sticky top-0 z-10 bg-white drop-shadow-lg">
+    <header className="sticky top-0 z-10 bg-white drop-shadow-lg dark:bg-stone-800">
       <nav className="navbar mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-8">
         <div className="logo">
           <Link href="/" className="text-2xl font-bold">
-            <h1 className="flex items-center gap-1.5 font-bold text-slate-800">
+            <h1 className="flex items-center gap-1.5 font-bold text-slate-800 dark:text-white">
               <GiAcorn className="text-3xl" />
               Dotori Blog
             </h1>

--- a/src/components/layout/posts/CategorizedPosts.tsx
+++ b/src/components/layout/posts/CategorizedPosts.tsx
@@ -28,7 +28,7 @@ export default function CategorizedPosts({ blogs, categories }: Props) {
         setCurrentCategory={setCurrentCategory}
       />
       <article className="mt-6">
-        <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl">
+        <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl dark:text-white">
           {currentCategory} Posts
         </h2>
         <PostList blogs={filteredPosts} />

--- a/src/components/layout/posts/FeaturedPosts.tsx
+++ b/src/components/layout/posts/FeaturedPosts.tsx
@@ -7,7 +7,7 @@ export default async function FeaturedPosts() {
 
   return (
     <section className="mt-6">
-      <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl">
+      <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl dark:text-white">
         Featured Posts
       </h2>
       <PostList blogs={blogs} />

--- a/src/components/layout/posts/PostItem.tsx
+++ b/src/components/layout/posts/PostItem.tsx
@@ -17,7 +17,7 @@ export default function PostItem({
 
   return (
     <Link href={`/posts/${slug}`}>
-      <article className="group relative flex h-32 w-full cursor-pointer select-none rounded-lg bg-white px-1 shadow-lg lg:h-80 lg:flex-col lg:p-2">
+      <article className="group relative flex h-32 w-full cursor-pointer select-none rounded-lg bg-white px-1 shadow-lg lg:h-80 lg:flex-col lg:p-2 dark:shadow-slate-400">
         <Image
           src={coverImage || '/images/default-cover.jpg'}
           alt="post-thumbnail"
@@ -31,10 +31,10 @@ export default function PostItem({
               <span key={index}>#{category} </span>
             ))}
           </div>
-          <h3 className="mb-1.5 line-clamp-2 text-sm font-bold group-hover:text-rose-600 lg:text-base lg:leading-snug">
+          <h3 className="mb-1.5 line-clamp-2 text-sm font-bold group-hover:text-rose-600 lg:text-base lg:leading-snug text-black">
             {title}
           </h3>
-          <p className="line-clamp-2 text-xs lg:line-clamp-3 lg:text-sm lg:leading-snug">
+          <p className="line-clamp-2 text-xs lg:line-clamp-3 lg:text-sm lg:leading-snug text-black">
             {description}
           </p>
         </div>

--- a/src/components/layout/posts/RegularPosts.tsx
+++ b/src/components/layout/posts/RegularPosts.tsx
@@ -6,7 +6,7 @@ export default async function RegularPosts() {
   const blogs = await getRegularBlogs();
   return (
     <section className="mt-12">
-      <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl">
+      <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl dark:text-white">
         You May Like
       </h2>
       <CarouselPosts blogs={blogs} />

--- a/src/components/markdownHeader/index.tsx
+++ b/src/components/markdownHeader/index.tsx
@@ -27,7 +27,7 @@ export default function MarkdownHeader({ blog }: Props) {
             </a>
           </div>
           <div className="ml-3">
-            <p className="!mb-0 text-sm font-medium text-gray-900">
+            <p className="!mb-0 text-sm font-medium text-gray-900 dark:text-white">
               <a href="#" className="hover:underline">
                 {blog.author}
               </a>
@@ -45,7 +45,7 @@ export default function MarkdownHeader({ blog }: Props) {
       <h1 className="mb-1 break-all text-2xl font-bold sm:text-4xl">
         {blog.title}
       </h1>
-      <p className="blog-detail-header-subtitle my-4 text-lg text-gray-600 sm:text-xl">
+      <p className="blog-detail-header-subtitle my-4 text-lg text-gray-600 sm:text-xl dark:text-gray-400">
         {blog.description}
       </p>
       <div className="relative mx-auto h-72 w-full bg-purple-100 sm:h-80 md:h-96">

--- a/src/components/markdownViewer/index.tsx
+++ b/src/components/markdownViewer/index.tsx
@@ -14,7 +14,7 @@ type Props = {
 export default function MarkdownViewer({ content }: Props) {
   return (
     <ReactMarkdown
-      className="prose min-w-full lg:prose-xl"
+      className="prose min-w-full lg:prose-xl dark:text-white markdown-viewer"
       remarkPlugins={[remarkGfm]}
       components={{
         code({ node, inline, className, children, ...props }) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,5 +18,6 @@ module.exports = {
     },
   },
   mode: 'jit',
+  darkMode: 'class',
   plugins: [require('@tailwindcss/typography')],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2758,6 +2758,11 @@ next-sitemap@^4.1.3:
     fast-glob "^3.2.12"
     minimist "^1.2.8"
 
+next-themes@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.2.1.tgz#0c9f128e847979daf6c67f70b38e6b6567856e45"
+  integrity sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==
+
 next@^13.4.4:
   version "13.4.4"
   resolved "https://registry.yarnpkg.com/next/-/next-13.4.4.tgz#d1027c8d77f4c51be0b39f671b4820db03c93e60"
@@ -3323,7 +3328,7 @@ regexp.prototype.flags@^1.4.3:
 
 remark-gfm@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-3.0.1.tgz#0b180f095e3036545e9dddac0e8df3fa5cfee54f"
   integrity sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==
   dependencies:
     "@types/mdast" "^3.0.0"


### PR DESCRIPTION
- 블로그 다크모드 적용
- next-themes 를 적용하기 위한 Providers 컴포넌트 생성
- tailwind config 에 darkMode: 'class' 추가
- 클래스명 접두어 dark: 로 시작하여 다크 모드일 때 색상 적용 가능
<img width="1723" alt="스크린샷 2023-06-09 오후 10 20 12" src="https://github.com/seolleung2/dotorimook-log/assets/69143207/7efa3c83-189f-40de-92a1-e8a105dc315e">
